### PR TITLE
[FIX] Compile Clang OSX 12.5

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerIterative.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerIterative.h
@@ -334,7 +334,7 @@ public:
         if (input[k].getMZ() > picked_spectrum[j].getMZ())
         {
           LOG_DEBUG << "got a value " << k << " @ " << input[k] << std::endl;
-          PeakCandidate pc = { /*.index=*/ k, /*.intensity=*/ picked_spectrum[j].getIntensity(), -1, -1, -1, -1};
+          PeakCandidate pc = { /*.index=*/ static_cast<int>(k), /*.intensity=*/ picked_spectrum[j].getIntensity(), -1, -1, -1, -1};
           newPeakCandidates_.push_back(pc);
           j++;
         }


### PR DESCRIPTION
Following error occured:

PeakPickerIterative.h:337:44: error: non-constant-expression cannot be narrowed from type 'Size'
      (aka 'unsigned long') to 'int' in initializer list [-Wc++11-narrowing]
          PeakCandidate pc = { /*.index=*/ k, /*.intensity=*/ picked_spectrum[j].getIntensity(), -1, -1, -1, -1};

fixed by commit